### PR TITLE
Add RedHat support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.molecule
+00aptproxy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ test:
 
     # test for other zsh_user
     - molecule create
-    - docker exec -i ansible-role-zsh useradd testuser --create-home
+    - docker exec -i ansible-role-zsh-ubuntu useradd testuser --create-home
+    - docker exec -i ansible-role-zsh-centos useradd testuser --create-home
     - MOLECULE_ZSH_USER=testuser molecule --debug converge
     - molecule destroy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ script:
 
   # test for other zsh_user
   - molecule create
-  - docker exec -i ansible-role-zsh useradd testuser --create-home
+  - docker exec -i ansible-role-zsh-ubuntu useradd testuser --create-home
+  - docker exec -i ansible-role-zsh-centos useradd testuser --create-home
   - MOLECULE_ZSH_USER=testuser molecule --debug converge
   - molecule destroy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/viasite-ansible/ansible-role-zsh.svg?branch=master)](https://travis-ci.org/viasite-ansible/ansible-role-zsh)
 
-Tested on Debian 6, Ubuntu 14.04, Ubuntu 16.04, macOS 10.12, CentOS 7.2.
+Tested on Debian 6, Ubuntu 14.04, Ubuntu 16.04, macOS 10.12, CentOS 7.
 
 Please, check settings in `defaults/main.yml` before provision!
 You can test role in vagrant:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/viasite-ansible/ansible-role-zsh.svg?branch=master)](https://travis-ci.org/viasite-ansible/ansible-role-zsh)
 
-Tested on Debian 6, Ubuntu 14.04, Ubuntu 16.04, macOS 10.12.
+Tested on Debian 6, Ubuntu 14.04, Ubuntu 16.04, macOS 10.12, CentOS 7.2.
 
 Please, check settings in `defaults/main.yml` before provision!
 You can test role in vagrant:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
       versions:
         - squeeze
         - wheezy
+    - name: EL
+      versions:
+        - 7
     - name: MacOSX
       versions:
         - 10.12

--- a/molecule.yml
+++ b/molecule.yml
@@ -6,11 +6,16 @@ driver:
   name: docker
 docker:
   containers:
-    - name: ansible-role-zsh
+    - name: ansible-role-zsh-ubuntu
       image: ubuntu
       image_version: 16.04
       volume_mounts:
         - ${MOLECULE_APTPROXY_PATH}:/etc/apt/apt.conf.d/00aptproxy
+      ansible_groups:
+        - group1
+    - name: ansible-role-zsh-centos
+      image: centos
+      image_version: 7
       ansible_groups:
         - group1
 

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -1,0 +1,15 @@
+---
+- name: Install zsh, git, wget
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - zsh
+    - git
+    - wget
+
+- name: Install tmux
+  yum:
+    name: tmux
+    state: present
+  when: "'tmux' in zsh_plugins"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,10 @@
   when: ansible_os_family == "Debian"
   tags: [ zsh, install ]
 
+- include: install-redhat.yml
+  when: ansible_os_family == "RedHat"
+  tags: [ zsh, install ]
+
 - include: install-osx.yml
   when: ansible_os_family == "Darwin"
   tags: [ zsh, install ]


### PR DESCRIPTION
This is a naive attempt to support RedHat OS family. I've tested it only on CentOS 7.2, but I think that `git`, `zsh`, `wget` and `tmux` are common enough to be present in default repo for every OS in this family.