### PR TITLE
Update configure.yml

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -48,6 +48,7 @@
   user:
     name: "{{ zsh_user }}"
     shell: /bin/zsh
+  become: true
 
 - name: Add skip_global_compinit for disable early compinit call in Ubuntu
   lineinfile:


### PR DESCRIPTION
Elevate privilidges with become: true for setting the current user shell, seems to be required on my 2017 Macbook Pro (macOS High Sierra 10.13.2)