### PR TITLE
Fix version filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Bundles `docker` and `docker-compose` will be added to config only if commands e
 ``` yaml
 # load only for zsh >= 4.3.17
 - name: zsh-users/zsh-syntax-highlighting
-  when: "{{ zsh_version | version_compare('4.3.17', '>=') }}"
+  when: "{{ zsh_version is version('4.3.17', '>=') }}"
 # load only for macOS
 - { name: brew, when: "{{ ansible_os_family != 'Darwin' }}" }
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ zsh_antigen_bundles:
   - zsh_reload
 
   # on zsh 4.3.10 autosuggestions breaks multiline commands with \
-  - { name: zsh-users/zsh-autosuggestions, when: "{{ zsh_version|default(false) | is version('5.0', '>=') }}" }
+  - { name: zsh-users/zsh-autosuggestions, when: "{{ zsh_version|default(false) is version('5.0', '>=') }}" }
   - popstas/zsh-command-time
   - { name: unixorn/autoupdate-antigen.zshplugin, when: "{{ zsh_update_interval > 0 }}" }
   - urbainvaes/fzf-marks # replaces jump plugin, mark, jump and Ctrl+G

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,15 +50,15 @@ zsh_antigen_bundles:
   - zsh_reload
 
   # on zsh 4.3.10 autosuggestions breaks multiline commands with \
-  - { name: zsh-users/zsh-autosuggestions, when: "{{ zsh_version | default(false) | version_compare('5.0', '>=') }}" }
+  - { name: zsh-users/zsh-autosuggestions, when: "{{ default(zsh_version, false) | is version('5.0', '>=') }}" }
   - popstas/zsh-command-time
   - { name: unixorn/autoupdate-antigen.zshplugin, when: "{{ zsh_update_interval > 0 }}" }
   - urbainvaes/fzf-marks # replaces jump plugin, mark, jump and Ctrl+G
   - "{{ fzf_widgets }}"
   # must be last, don't work on zsh < 4.3.17
-  #- { name: zsh-users/zsh-syntax-highlighting, when: "{{ zsh_version | default(false) | version_compare('4.3.17', '>=') }}" }
+  #- { name: zsh-users/zsh-syntax-highlighting, when: "{{  default(zsh_version, false) is version('4.3.17', '>=') }}" }
   # bug with text paste in fast-syntax-highlighting v1.21, see https://github.com/zdharma/fast-syntax-highlighting/issues/30
-  - { name: zdharma/fast-syntax-highlighting@v1.2, when: "{{ zsh_version | default(false) | version_compare('4.3.17', '>=') }}" }
+  - { name: zdharma/fast-syntax-highlighting@v1.2, when: "{{  default(zsh_version, false) is version('4.3.17', '>=') }}" }
 
 zsh_antigen_bundles_extras: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,15 +50,15 @@ zsh_antigen_bundles:
   - zsh_reload
 
   # on zsh 4.3.10 autosuggestions breaks multiline commands with \
-  - { name: zsh-users/zsh-autosuggestions, when: "{{ default(zsh_version, false) | is version('5.0', '>=') }}" }
+  - { name: zsh-users/zsh-autosuggestions, when: "{{ zsh_version|default(false) | is version('5.0', '>=') }}" }
   - popstas/zsh-command-time
   - { name: unixorn/autoupdate-antigen.zshplugin, when: "{{ zsh_update_interval > 0 }}" }
   - urbainvaes/fzf-marks # replaces jump plugin, mark, jump and Ctrl+G
   - "{{ fzf_widgets }}"
   # must be last, don't work on zsh < 4.3.17
-  #- { name: zsh-users/zsh-syntax-highlighting, when: "{{  default(zsh_version, false) is version('4.3.17', '>=') }}" }
+  #- { name: zsh-users/zsh-syntax-highlighting, when: "{{  zsh_version|default(false) is version('4.3.17', '>=') }}" }
   # bug with text paste in fast-syntax-highlighting v1.21, see https://github.com/zdharma/fast-syntax-highlighting/issues/30
-  - { name: zdharma/fast-syntax-highlighting@v1.2, when: "{{  default(zsh_version, false) is version('4.3.17', '>=') }}" }
+  - { name: zdharma/fast-syntax-highlighting@v1.2, when: "{{  zsh_version|default(false) is version('4.3.17', '>=') }}" }
 
 zsh_antigen_bundles_extras: []
 

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -62,9 +62,9 @@ antigen bundle {{ bundle }}
 {% endif %}
 {% endfor %}
 
-{% if zsh_antigen_installed_version | version_compare(2.0, '>=') %}
+{% if zsh_antigen_installed_version is version(2.0, '>=') %}
 POWERLEVEL9K_INSTALLATION_PATH=$ANTIGEN_BUNDLES/bhilburn/powerlevel9k/powerlevel9k.zsh-theme
-{% elif zsh_version | version_compare('5.0.8', '<') %}
+{% elif zsh_version is version('5.0.8', '<') %}
 POWERLEVEL9K_INSTALLATION_PATH={{ zsh_antigen_path_compat }}/repos/https-COLON--SLASH--SLASH-github.com-SLASH-bhilburn-SLASH-powerlevel9k.git
 {% endif %}
 
@@ -101,7 +101,7 @@ export FZF_TMUX=0
 export FZF_DEFAULT_OPTS="{{ zsh_fzf_default_opts }}"
 
 # fzf-widgets: fzf-change-reset-dir
-{% if zsh_version | version_compare('5.0', '>=') -%}
+{% if zsh_version is version('5.0', '>=') -%}
 autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
 add-zsh-hook chpwd chpwd_recent_dirs
 {% endif %}


### PR DESCRIPTION
Could you merge this request ?

Ansible 2.9 has removed `version_compare` filter, this filter was deprecated since Ansible 2.5. And now, the test can be done with `is version`.

https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#version-comparison