### PR TITLE
Support Powerlevel10k Instant Prompt

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -191,3 +191,6 @@ zsh_powerlevel9k_vcs_untracked_background: "094" # orange
 # command execution time
 zsh_powerlevel9k_command_execution_time_foreground: "000"
 zsh_powerlevel9k_command_execution_time_background: "248"
+
+# powerlevel10k
+zsh_powerlevel10k_instant_prompt: no

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -6,6 +6,16 @@ export TERM="{{ zsh_term }}"
 export EDITOR="{{ zsh_editor }}"
 export PATH="$PATH:{{ zsh_path | join(":") }}"
 
+{% if zsh_antigen_theme == "romkatv/powerlevel10k powerlevel10k" and zsh_powerlevel10k_instant_prompt %}
+
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+# Initialization code that may require console input (password prompts, [y/n]
+# confirmations, etc.) must go above this block; everything else may go below.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+{% endif %}
+
 HIST_STAMPS="{{ zsh_hist_stamps }}"
 UPDATE_ZSH_DAYS="{{ zsh_update_interval }}"
 COMPLETION_WAITING_DOTS="true"

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -7,6 +7,8 @@ export EDITOR="{{ zsh_editor }}"
 export PATH="$PATH:{{ zsh_path | join(":") }}"
 
 {% if zsh_antigen_theme == "romkatv/powerlevel10k powerlevel10k" and zsh_powerlevel10k_instant_prompt %}
+# user configs
+[[ -r "$HOME/.zshrc.local.pre-p10k" ]] && source "$HOME/.zshrc.local.pre-p10k"
 
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -171,3 +171,8 @@ alias suser='su -'
 # user configs
 [[ -r /etc/zsh/zshrc.local ]] && source /etc/zsh/zshrc.local
 [[ -r "$HOME/.zshrc.local" ]] && source "$HOME/.zshrc.local"
+
+{% if zsh_antigen_theme == "romkatv/powerlevel10k powerlevel10k" %}
+# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+#[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+{% endif %}

--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -186,5 +186,5 @@ alias suser='su -'
 
 {% if zsh_antigen_theme == "romkatv/powerlevel10k powerlevel10k" %}
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-#[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 {% endif %}


### PR DESCRIPTION
The code to enable Powerlevel10k's Instant Prompt needs to be placed near the start of `~/.zshrc` according to the [documentation](https://github.com/romkatv/powerlevel10k#how-do-i-enable-instant-prompt). Since Ansible is managing `~/.zshrc`, letting `p10k configure` add this code is not an option, and `~/.zshrc.local` is not a suitable place for it. This patch therefore handles inserting the relevant code into `~/.zshrc`, additionally adding a second include (`~/.zshrc.local.pre-10k`) allowing for any init code that needs to run before Instant Prompt is enabled