### PR TITLE
fixed it

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -5,7 +5,7 @@ zsh_config: "{% if zsh_shared %}/usr/share/zsh-config/.zshrc{% else %}~{{ zsh_us
 zsh_antigen_path_compat: "{{ zsh_antigen_path | replace('~' + zsh_user, '$HOME') }}"
 
 zsh_fzf_os: linux
-zsh_fzf_arch: "{% if '64' in ansible_architecture %}amd64{% else %}386{% endif %}"
+zsh_fzf_arch: "{% if '64' in ansible_architecture %}amd64{% elif 'arm' in ansible_architecture %}amd64{% else %}386{% endif %}"
 zsh_fzf_url: "https://github.com/junegunn/fzf/releases/download/{{ zsh_fzf_version }}/fzf-{{ zsh_fzf_version }}-{{ zsh_fzf_os }}_{{ zsh_fzf_arch }}.tar.gz"
 zsh_antigen_fzf_path: "{{ zsh_antigen_path }}/repos/https-COLON--SLASH--SLASH-github.com-SLASH-junegunn-SLASH-fzf.git"
 zsh_fzf_default_opts: "--height {{ zsh_fzf_height }}{% if zsh_fzf_reverse %} --reverse{% endif %}{% if zsh_fzf_border %} --border{% endif %}"


### PR DESCRIPTION
```bash
TASK [viasite-ansible.zsh : Download fzf to ~root/bin] **********************************************************************************
task path: /home/leonch/.ansible/roles/viasite-ansible.zsh/tasks/install.yml:66
skipping: [quantumhome] => {"changed": false, "msg": "skipped, since /root/bin/fzf exists"}
changed: [raspberrypi] => {"changed": true, "dest": "/root/bin", "extract_results": {"cmd": ["/usr/bin/tar", "--extract", "-C", "/root/bin", "-z", "-f", "/home/pi/.ansible/tmp/ansible-tmp-1661070689.7166157-506004-34118930365121/fzf-0.28.0-linux_amd64.taretowshtv.gz"], "err": "", "out": "", "rc": 0}, "gid": 0, "group": "root", "handler": "TgzArchive", "mode": "0775", "owner": "root", "size": 4096, "src": "/home/pi/.ansible/tmp/ansible-tmp-1661070689.7166157-506004-34118930365121/fzf-0.28.0-linux_amd64.taretowshtv.gz", "state": "directory", "uid": 0}
```