### PR TITLE
Fix Create cache dirs

### DIFF
--- a/tasks/post-install.yml
+++ b/tasks/post-install.yml
@@ -20,7 +20,7 @@
     state: directory
     recurse: yes
     owner: "{{ zsh_user }}"
-    group: "{{ zsh_user }}"
+    group: "{{ zsh_user_group }}"
   become: yes
   with_items:
     - "{{ zsh_antigen_path }}/bundles/robbyrussell/oh-my-zsh/cache/completions"


### PR DESCRIPTION
For Create cache dirs use zsh_user_group for the group instead of zsh_user