### PR TITLE
Added support for docker compose plugin

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ zsh_antigen_bundles:
   - { name: brew, when: "{{ ansible_os_family == 'Darwin' }}" }
   - { name: docker, command: docker }
   - { name: docker-compose, command: docker-compose }
+  - { name: docker-compose, command: docker compose }
   - fancy-ctrl-z
   - git-extras
   - gnu-utils


### PR DESCRIPTION
Added support for docker compose plugin, which uses the command "docker compose" instead of "docker-compose"